### PR TITLE
Add a workflow release

### DIFF
--- a/.github/workflows/Zip-it.yml
+++ b/.github/workflows/Zip-it.yml
@@ -28,7 +28,11 @@ jobs:
 
       # Runs a set of commands using the runners shell
       - name: zip it
-        run: zip -r wpm.zip *
+        run: |
+                mkdir bin share
+                mv wpm.sh bin/wpm
+                mv repos share
+                zip -r wpm.zip bin share
 
       - name: setup release
         uses: spenserblack/actions-tag-to-release@master

--- a/.github/workflows/Zip-it.yml
+++ b/.github/workflows/Zip-it.yml
@@ -6,7 +6,6 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the bash branch
   push:
-    branches: [ master ]
     tags: [ 'release-*' ]
 
   # Allows you to run this workflow manually from the Actions tab
@@ -23,22 +22,18 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: checkout code
-        if: startsWith(github.ref, 'refs/tags')
         uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
 
       # Runs a set of commands using the runners shell
       - name: zip it
-        if: startsWith(github.ref, 'refs/tags')
         run: zip -r wpm.zip *
 
       - name: setup release
-        if: startsWith(github.ref, 'refs/tags')
         uses: spenserblack/actions-tag-to-release@master
 
       - name: Make release
-        if: startsWith(github.ref, 'refs/tags')
         uses: softprops/action-gh-release@v1
         with:
           files: wpm.zip

--- a/.github/workflows/Zip-it.yml
+++ b/.github/workflows/Zip-it.yml
@@ -1,0 +1,44 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the bash branch
+  push:
+    branches: [ master ]
+    tags: [ 'release-*' ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: checkout code
+        if: startsWith(github.ref, 'refs/tags')
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      # Runs a set of commands using the runners shell
+      - name: zip it
+        if: startsWith(github.ref, 'refs/tags')
+        run: zip -r wpm.zip *
+
+      - name: setup release
+        if: startsWith(github.ref, 'refs/tags')
+        uses: spenserblack/actions-tag-to-release@master
+
+      - name: Make release
+        if: startsWith(github.ref, 'refs/tags')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: wpm.zip


### PR DESCRIPTION
create a release with a zip containing all the needed files

This will automatically create a github release on the creation of a `release-*` tag, 

if it's an annotated tag it will take the title and body from the annotation, otherwise it'll take it from the commit message