### PR TITLE
Generalize zip-it into it's own github action repo

### DIFF
--- a/.github/workflows/Zip-it.yml
+++ b/.github/workflows/Zip-it.yml
@@ -31,9 +31,8 @@ jobs:
         run: mv wpm.sh wpm
 
       - name: zip it
-        uses: tuxecure/zip-it@v2
+        uses: tuxecure/zip-it@v2.1
         with:
-          prefix: ${HOME}/.local
           pkg_directories: bin share
           bin: wpm
           data_directory: repos

--- a/.github/workflows/Zip-it.yml
+++ b/.github/workflows/Zip-it.yml
@@ -31,14 +31,13 @@ jobs:
         run: mv wpm.sh wpm
 
       - name: zip it
-        env:
-          PACKAGE_NAME: wpm
         uses: tuxecure/zip-it@v1.9
         with:
           prefix: ${HOME}/.local
           pkg_directories: bin share
           bin: wpm
           data_directory: repos
+          package_name: wpm
 
       - name: setup release
         uses: spenserblack/actions-tag-to-release@master

--- a/.github/workflows/Zip-it.yml
+++ b/.github/workflows/Zip-it.yml
@@ -40,7 +40,7 @@ jobs:
           package_name: wpm
 
       - name: setup release
-        uses: spenserblack/actions-tag-to-release@master
+        uses: spenserblack/actions-tag-to-release@v0.1.4
 
       - name: Make release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/Zip-it.yml
+++ b/.github/workflows/Zip-it.yml
@@ -31,7 +31,7 @@ jobs:
         run: mv wpm.sh wpm
 
       - name: zip it
-        uses: tuxecure/zip-it@v1.9
+        uses: tuxecure/zip-it@v2
         with:
           prefix: ${HOME}/.local
           pkg_directories: bin share

--- a/.github/workflows/Zip-it.yml
+++ b/.github/workflows/Zip-it.yml
@@ -31,14 +31,14 @@ jobs:
         run: mv wpm.sh wpm
 
       - name: zip it
-        uses: tuxecure/zip-it@v1.4
+        env:
+          PACKAGE_NAME: wpm
+        uses: tuxecure/zip-it@v1.9
         with:
           prefix: ${HOME}/.local
           pkg_directories: bin share
           bin: wpm
           data_directory: repos
-          maintainer: waydroid
-          package_name: wpm
 
       - name: setup release
         uses: spenserblack/actions-tag-to-release@master

--- a/.github/workflows/Zip-it.yml
+++ b/.github/workflows/Zip-it.yml
@@ -27,12 +27,18 @@ jobs:
           ref: ${{ github.ref }}
 
       # Runs a set of commands using the runners shell
+      - name: prepare for zipping
+        run: mv wpm.sh wpm
+
       - name: zip it
-        run: |
-                mkdir bin share
-                mv wpm.sh bin/wpm
-                mv repos share
-                zip -r wpm.zip bin share
+        uses: tuxecure/zip-it@v1.4
+        with:
+          prefix: ${HOME}/.local
+          pkg_directories: bin share
+          bin: wpm
+          data_directory: repos
+          maintainer: waydroid
+          package_name: wpm
 
       - name: setup release
         uses: spenserblack/actions-tag-to-release@master


### PR DESCRIPTION
* restructure the directory as bin share/wpm
* add an installation script; `wpm/wpm setup` will install wpm to the familiar directories
* wpm in the root is an installation script, the original wpm is in bin/wpm